### PR TITLE
Url message wordings

### DIFF
--- a/Topshelf.Nancy/UrlReservationsHelper.cs
+++ b/Topshelf.Nancy/UrlReservationsHelper.cs
@@ -29,15 +29,15 @@ namespace Topshelf.Nancy
 
                 if (result.ResultCode == NetShResultCode.Error)
                 {
-                    Logger.Error(string.Format("[Topshelf.Nancy] Error deleting URL Reservation {0} with command: netsh {1}. {2}",
-                        prefix, result.CommandRan, result.Message));
+                    var message = string.Format("[Topshelf.Nancy] Error deleting URL Reservation {0} with command: netsh {1}. {2}", prefix, result.CommandRan, result.Message);
+                    Logger.Error(message);
                     return false;
                 }
 
                 if (result.ResultCode == NetShResultCode.UrlReservationDoesNotExist)
                 {
-                    Logger.Warn(string.Format("[Topshelf.Nancy] Could not delete URL Reservation {0} because it does not exist. Treating as a success.", 
-                        prefix));
+                    var message = string.Format("[Topshelf.Nancy] Could not delete URL Reservation {0} because it does not exist. Treating as a success.", prefix);
+                    Logger.Warn(message);
                 }
             }
 
@@ -57,8 +57,8 @@ namespace Topshelf.Nancy
             var result = NetSh.OpenFirewallPorts(portList, user, firewallRuleName);
             if (result.ResultCode == NetShResultCode.Error)
             {
-                Logger.Error(string.Format("[Topshelf.Nancy] Error opening firewall ports {0}: netsh {1}. {2}", 
-                    portList, result.CommandRan, result.Message));
+                var message = string.Format("[Topshelf.Nancy] Error opening firewall ports {0}: netsh {1}. {2}", portList, result.CommandRan, result.Message);
+                Logger.Error(message);
                 return false;
             }
 
@@ -77,15 +77,15 @@ namespace Topshelf.Nancy
                 var result = NetSh.AddUrlAcl(prefix, user);
                 if (result.ResultCode == NetShResultCode.Error)
                 {
-                    Logger.Error(string.Format("[Topshelf.Nancy] Error adding URL Reservation {0} with command: netsh {1}. {2}", 
-                        prefix, result.CommandRan, result.Message));
+                    var message = string.Format("[Topshelf.Nancy] Error adding URL Reservation {0} with command: netsh {1}. {2}", prefix, result.CommandRan, result.Message);
+                    Logger.Error(message);
                     return false;
                 }
 
                 if (result.ResultCode == NetShResultCode.UrlReservationAlreadyExists)
                 {
-                    Logger.Warn(string.Format("[Topshelf.Nancy] Could not add URL Reservation {0} because it already exists. Treating as a success.",
-                        prefix));
+                    var message = string.Format("[Topshelf.Nancy] Could not add URL Reservation {0} because it already exists. Treating as a success.", prefix);
+                    Logger.Warn(message);
                     return true;
                 }
             }

--- a/Topshelf.Nancy/UrlReservationsHelper.cs
+++ b/Topshelf.Nancy/UrlReservationsHelper.cs
@@ -80,7 +80,7 @@ namespace Topshelf.Nancy
 
                 if (result.ResultCode == NetShResultCode.UrlReservationAlreadyExists)
                 {
-                    Logger.Warn("[Topshelf.Nancy] Could not add URL Reservation becuase it already exists. Treating as a success.");
+                    Logger.Warn("[Topshelf.Nancy] Could not add URL Reservation because it already exists. Treating as a success.");
                     return true;
                 }
             }

--- a/Topshelf.Nancy/UrlReservationsHelper.cs
+++ b/Topshelf.Nancy/UrlReservationsHelper.cs
@@ -74,7 +74,7 @@ namespace Topshelf.Nancy
                 var result = NetSh.AddUrlAcl(prefix, user);
                 if (result.ResultCode == NetShResultCode.Error)
                 {
-                    Logger.Error(string.Format("[Topshelf.Nancy] Error deleting URL Reservation with command: netsh {0}. {1}", result.CommandRan, result.Message));
+                    Logger.Error(string.Format("[Topshelf.Nancy] Error adding URL Reservation with command: netsh {0}. {1}", result.CommandRan, result.Message));
                     return false;
                 }
 

--- a/Topshelf.Nancy/UrlReservationsHelper.cs
+++ b/Topshelf.Nancy/UrlReservationsHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Principal;
 using Nancy.Hosting.Self;
 using Topshelf.Logging;
@@ -68,11 +69,14 @@ namespace Topshelf.Nancy
 
         public bool AddUrlReservations(bool shouldOpenFirewallPorts = false)
         {
-            Logger.Info("[Topshelf.Nancy] Adding URL Reservations");
+            var prefixes = GetPrefixes().ToList();
+            var urlText = prefixes.Count == 1 ? "url" : "urls";
+            var startMessage = string.Format("[Topshelf.Nancy] Adding Reservations for {0} {1}", prefixes.Count, urlText);
+            Logger.Info(startMessage);
 
             var user = GetUser();
 
-            foreach (var prefix in GetPrefixes())
+            foreach (var prefix in prefixes)
             {
                 var result = NetSh.AddUrlAcl(prefix, user);
                 if (result.ResultCode == NetShResultCode.Error)

--- a/Topshelf.Nancy/UrlReservationsHelper.cs
+++ b/Topshelf.Nancy/UrlReservationsHelper.cs
@@ -70,9 +70,7 @@ namespace Topshelf.Nancy
         public bool AddUrlReservations(bool shouldOpenFirewallPorts = false)
         {
             var prefixes = GetPrefixes().ToList();
-            var urlText = prefixes.Count == 1 ? "url" : "urls";
-            var startMessage = string.Format("[Topshelf.Nancy] Adding Reservations for {0} {1}", prefixes.Count, urlText);
-            Logger.Info(startMessage);
+            LogUrlReservations(prefixes);
 
             var user = GetUser();
 
@@ -97,6 +95,23 @@ namespace Topshelf.Nancy
             Logger.Info("[Topshelf.Nancy] URL Reservations added");
 
             return true;
+        }
+
+        private static void LogUrlReservations(IList<string> prefixes)
+        {
+            if (prefixes.Count == 0)
+            {
+                Logger.Warn("[Topshelf.Nancy] No URL reservations found.");
+            }
+            else if (prefixes.Count == 1)
+            {
+                Logger.Info("[Topshelf.Nancy] Adding Reservation for one URL: " + prefixes[0]);
+            }
+            else
+            {
+                var message = string.Format("[Topshelf.Nancy] Adding Reservations for {0} URLs.", prefixes.Count);
+                Logger.Info(message);
+            }
         }
 
         private string GetUser()

--- a/Topshelf.Nancy/UrlReservationsHelper.cs
+++ b/Topshelf.Nancy/UrlReservationsHelper.cs
@@ -29,13 +29,15 @@ namespace Topshelf.Nancy
 
                 if (result.ResultCode == NetShResultCode.Error)
                 {
-                    Logger.Error(string.Format("[Topshelf.Nancy] Error deleting URL Reservation with command: netsh {0}. {1}", result.CommandRan, result.Message));
+                    Logger.Error(string.Format("[Topshelf.Nancy] Error deleting URL Reservation {0} with command: netsh {1}. {2}",
+                        prefix, result.CommandRan, result.Message));
                     return false;
                 }
 
                 if (result.ResultCode == NetShResultCode.UrlReservationDoesNotExist)
                 {
-                    Logger.Warn("[Topshelf.Nancy] Could not delete URL Reservation because it does not exist. Treating as a success.");
+                    Logger.Warn(string.Format("[Topshelf.Nancy] Could not delete URL Reservation {0} because it does not exist. Treating as a success.", 
+                        prefix));
                 }
             }
 
@@ -55,7 +57,8 @@ namespace Topshelf.Nancy
             var result = NetSh.OpenFirewallPorts(portList, user, firewallRuleName);
             if (result.ResultCode == NetShResultCode.Error)
             {
-                Logger.Error(string.Format("[Topshelf.Nancy] Error opening firewall port: netsh {0}. {1}", result.CommandRan, result.Message));
+                Logger.Error(string.Format("[Topshelf.Nancy] Error opening firewall ports {0}: netsh {1}. {2}", 
+                    portList, result.CommandRan, result.Message));
                 return false;
             }
 
@@ -74,13 +77,15 @@ namespace Topshelf.Nancy
                 var result = NetSh.AddUrlAcl(prefix, user);
                 if (result.ResultCode == NetShResultCode.Error)
                 {
-                    Logger.Error(string.Format("[Topshelf.Nancy] Error adding URL Reservation with command: netsh {0}. {1}", result.CommandRan, result.Message));
+                    Logger.Error(string.Format("[Topshelf.Nancy] Error adding URL Reservation {0} with command: netsh {1}. {2}", 
+                        prefix, result.CommandRan, result.Message));
                     return false;
                 }
 
                 if (result.ResultCode == NetShResultCode.UrlReservationAlreadyExists)
                 {
-                    Logger.Warn("[Topshelf.Nancy] Could not add URL Reservation because it already exists. Treating as a success.");
+                    Logger.Warn(string.Format("[Topshelf.Nancy] Could not add URL Reservation {0} because it already exists. Treating as a success.",
+                        prefix));
                     return true;
                 }
             }


### PR DESCRIPTION
Better wordings in `UrlReservationsHelper`
Some typo fixes
More details in errors - which url prefix or port failed. We now often have multiple urls registered, so need to know which one failed
Log how many url reservations are being attempted, makes it easier to see if this differs from wheat is expected
Warn when there are no reservations