### PR TITLE
Update to Topshelf 4.0.1

### DIFF
--- a/Topshelf.Nancy.Sample/Topshelf.Nancy.Sample.csproj
+++ b/Topshelf.Nancy.Sample/Topshelf.Nancy.Sample.csproj
@@ -42,8 +42,8 @@
     </StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Nancy, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nancy.1.4.1\lib\net40\Nancy.dll</HintPath>
+    <Reference Include="Nancy, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nancy.1.4.3\lib\net40\Nancy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
@@ -54,12 +54,12 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ServiceProcess" />
-    <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.4.0.0\lib\net452\Topshelf.dll</HintPath>
+    <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.4.0.1\lib\net452\Topshelf.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Topshelf.NLog, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.NLog.4.0.0\lib\net452\Topshelf.NLog.dll</HintPath>
+    <Reference Include="Topshelf.NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.NLog.4.0.1\lib\net452\Topshelf.NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Topshelf.Nancy.Sample/Topshelf.Nancy.Sample.csproj
+++ b/Topshelf.Nancy.Sample/Topshelf.Nancy.Sample.csproj
@@ -47,19 +47,19 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.2.0\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.3.3\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ServiceProcess" />
-    <Reference Include="Topshelf, Version=3.2.150.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.3.2.0\lib\net40-full\Topshelf.dll</HintPath>
+    <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.4.0.0\lib\net452\Topshelf.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Topshelf.NLog, Version=3.2.150.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.NLog.3.2.0\lib\net40-full\Topshelf.NLog.dll</HintPath>
+    <Reference Include="Topshelf.NLog, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.NLog.4.0.0\lib\net452\Topshelf.NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Topshelf.Nancy.Sample/packages.config
+++ b/Topshelf.Nancy.Sample/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Nancy" version="1.4.1" targetFramework="net452" />
+  <package id="Nancy" version="1.4.3" targetFramework="net452" />
   <package id="NLog" version="4.3.3" targetFramework="net452" />
-  <package id="Topshelf" version="4.0.0" targetFramework="net452" />
-  <package id="Topshelf.NLog" version="4.0.0" targetFramework="net452" />
+  <package id="Topshelf" version="4.0.1" targetFramework="net452" />
+  <package id="Topshelf.NLog" version="4.0.1" targetFramework="net452" />
 </packages>

--- a/Topshelf.Nancy.Sample/packages.config
+++ b/Topshelf.Nancy.Sample/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Nancy" version="1.4.1" targetFramework="net452" />
-  <package id="NLog" version="4.2.0" targetFramework="net452" />
-  <package id="Topshelf" version="3.2.0" targetFramework="net452" />
-  <package id="Topshelf.NLog" version="3.2.0" targetFramework="net452" />
+  <package id="NLog" version="4.3.3" targetFramework="net452" />
+  <package id="Topshelf" version="4.0.0" targetFramework="net452" />
+  <package id="Topshelf.NLog" version="4.0.0" targetFramework="net452" />
 </packages>

--- a/Topshelf.Nancy/Topshelf.Nancy.csproj
+++ b/Topshelf.Nancy/Topshelf.Nancy.csproj
@@ -34,8 +34,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Nancy, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nancy.1.4.1\lib\net40\Nancy.dll</HintPath>
+    <Reference Include="Nancy, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nancy.1.4.3\lib\net40\Nancy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Nancy.Hosting.Self, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
@@ -45,8 +45,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.4.0.0\lib\net452\Topshelf.dll</HintPath>
+    <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.4.0.1\lib\net452\Topshelf.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Topshelf.Nancy/Topshelf.Nancy.csproj
+++ b/Topshelf.Nancy/Topshelf.Nancy.csproj
@@ -45,8 +45,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Topshelf, Version=3.2.150.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.3.2.0\lib\net40-full\Topshelf.dll</HintPath>
+    <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.4.0.0\lib\net452\Topshelf.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Topshelf.Nancy/packages.config
+++ b/Topshelf.Nancy/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Nancy" version="1.4.1" targetFramework="net452" />
+  <package id="Nancy" version="1.4.3" targetFramework="net452" />
   <package id="Nancy.Hosting.Self" version="1.4.1" targetFramework="net452" />
-  <package id="Topshelf" version="4.0.0" targetFramework="net452" />
+  <package id="Topshelf" version="4.0.1" targetFramework="net452" />
 </packages>

--- a/Topshelf.Nancy/packages.config
+++ b/Topshelf.Nancy/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Nancy" version="1.4.1" targetFramework="net452" />
   <package id="Nancy.Hosting.Self" version="1.4.1" targetFramework="net452" />
-  <package id="Topshelf" version="3.2.0" targetFramework="net452" />
+  <package id="Topshelf" version="4.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Update to [Topshelf 4.0](https://www.nuget.org/packages/Topshelf/4.0.0) released 3rd May 2016.
(and Topshelf.NLog  4.0 to match, and NLog.4.3.3)
this might be a breaking change?
For https://github.com/justeat/Topshelf.Nancy/issues/20
